### PR TITLE
test: initial parser tests

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -252,7 +252,7 @@ func TestParseStructsOk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseStructs(tt.args.fullpath, tt.args.src)
-			wantErr := error(nil)
+			var wantErr error = nil
 			if err != wantErr {
 				t.Errorf("parseStructs() error = %v, wantErr %v", err, wantErr)
 				return

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,288 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func Test_parseStructsOk(t *testing.T) {
+	type args struct {
+		fullpath string
+		src      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*Struct
+	}{
+		{
+			name: "No structs definition",
+			args: args{
+				fullpath: "example/main.go",
+				src: `package main
+		func main() {
+		}
+		`,
+			},
+			want: []*Struct{},
+		},
+
+		{
+			name: "One struct definition",
+			args: args{
+				fullpath: "example/main.go",
+				src: "package main\n" +
+					"type AllTypes struct {\n" +
+					"	FirstName string `valid:\"required\"`\n" +
+					"	LastName  string `valid:\"required\"`\n" +
+					"	Age       uint8  `valid:\"gte=18,lte=130\"`\n" +
+					"	UserName  string `valid:\"min=5,max=10\"`\n" +
+					"	Optional  string\n" +
+					"}\n" +
+					"func main() {\n" +
+					"}\n",
+			},
+			want: []*Struct{
+				{
+					StructName:  "AllTypes",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "FirstName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "LastName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "Age",
+							Type:      "uint8",
+							Tag:       "valid:\"gte=18,lte=130\"",
+						},
+						{
+							FieldName: "UserName",
+							Type:      "string",
+							Tag:       "valid:\"min=5,max=10\"",
+						},
+						{
+							FieldName: "Optional",
+							Type:      "string",
+							Tag:       "",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+			},
+		},
+
+		{
+			name: "One struct with validations and one struct without validations",
+			args: args{
+				fullpath: "example/main.go",
+				src: "package main\n" +
+					"type AllTypes struct {\n" +
+					"	FirstName string `valid:\"required\"`\n" +
+					"	LastName  string `valid:\"required\"`\n" +
+					"}\n" +
+					"\n" +
+					"type NoValidations struct {\n" +
+					"	Field1 string\n" +
+					"	Field2 uint8\n" +
+					"}\n" +
+					"func main() {\n" +
+					"}\n",
+			},
+			want: []*Struct{
+				{
+					StructName:  "AllTypes",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "FirstName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "LastName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+				{
+					StructName:  "NoValidations",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "Field1",
+							Type:      "string",
+							Tag:       "",
+						},
+						{
+							FieldName: "Field2",
+							Type:      "uint8",
+							Tag:       "",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+			},
+		},
+
+		{
+			name: "Struct definition in pkg",
+			args: args{
+				fullpath: "example/main.go",
+				src: "package main\n" +
+					"import \"github.com/opencodeco/validgen/tests/endtoend/inpkg\"\n" +
+					"type User struct {\n" +
+					"	FirstName string `valid:\"required\"`\n" +
+					"	LastName  string `valid:\"required\"`\n" +
+					"	Address inpkg.TypeAddress `valid:\"required\"`\n" +
+					"}\n" +
+					"\n" +
+					"func main() {\n" +
+					"}\n",
+			},
+			want: []*Struct{
+				{
+					StructName:  "User",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "FirstName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "LastName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "Address",
+							Type:      "inpkg.TypeAddress",
+							Tag:       "valid:\"required\"",
+						},
+					},
+					Imports: map[string]Import{
+						"inpkg": {
+							Name: "inpkg",
+							Path: "github.com/opencodeco/validgen/tests/endtoend/inpkg",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "Nested structs",
+			args: args{
+				fullpath: "example/main.go",
+				src: "package main\n" +
+					"type User struct {\n" +
+					"	FirstName string `valid:\"required\"`\n" +
+					"	LastName  string `valid:\"required\"`\n" +
+					"	Address   TypeAddress `valid:\"required\"`\n" +
+					"}\n" +
+					"type TypeAddress struct {\n" +
+					"	Street string `valid:\"required\"`\n" +
+					"	City string `valid:\"required\"`\n" +
+					"}\n" +
+					"\n" +
+					"func main() {\n" +
+					"}\n",
+			},
+			want: []*Struct{
+				{
+					StructName:  "User",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "FirstName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "LastName",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "Address",
+							Type:      "main.TypeAddress",
+							Tag:       "valid:\"required\"",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+				{
+					StructName:  "TypeAddress",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "Street",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "City",
+							Type:      "string",
+							Tag:       "valid:\"required\"",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseStructs(tt.args.fullpath, tt.args.src)
+			var wantErr error = nil
+			if err != wantErr {
+				t.Errorf("parseStructs() error = %v, wantErr %v", err, wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				gotStr := structsContentHelper(got)
+				wantStr := structsContentHelper(tt.want)
+				dmp := diffmatchpatch.New()
+				diffs := dmp.DiffMain(wantStr, gotStr, false)
+				if len(diffs) > 1 {
+					t.Errorf("parseStructs() diff = \n%v", dmp.DiffPrettyText(diffs))
+				}
+			}
+		})
+	}
+}
+
+func structsContentHelper(structs []*Struct) string {
+	var result string
+	for _, s := range structs {
+		result += "Struct: " + s.StructName + "\n"
+		result += "Path: " + s.Path + "\n"
+		result += "PackageName: " + s.PackageName + "\n"
+		for _, f := range s.Fields {
+			result += "  Field: " + f.FieldName + " Type: " + f.Type + " Tag: " + f.Tag + "\n"
+		}
+		for _, v := range s.Imports {
+			result += "  Import: " + v.Name + " Path: " + v.Path + "\n"
+		}
+	}
+
+	return result
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-func Test_parseStructsOk(t *testing.T) {
+func TestParseStructsOk(t *testing.T) {
 	type args struct {
 		fullpath string
 		src      string
@@ -252,16 +252,16 @@ func Test_parseStructsOk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseStructs(tt.args.fullpath, tt.args.src)
-			var wantErr error = nil
+			wantErr := error(nil)
 			if err != wantErr {
 				t.Errorf("parseStructs() error = %v, wantErr %v", err, wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				gotStr := structsContentHelper(got)
-				wantStr := structsContentHelper(tt.want)
+				gotStr := structsToString(got)
+				wantStr := structsToString(tt.want)
 				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(wantStr, gotStr, false)
+				diffs := dmp.DiffMain(gotStr, wantStr, false)
 				if len(diffs) > 1 {
 					t.Errorf("parseStructs() diff = \n%v", dmp.DiffPrettyText(diffs))
 				}
@@ -270,7 +270,7 @@ func Test_parseStructsOk(t *testing.T) {
 	}
 }
 
-func structsContentHelper(structs []*Struct) string {
+func structsToString(structs []*Struct) string {
 	var result string
 	for _, s := range structs {
 		result += "Struct: " + s.StructName + "\n"


### PR DESCRIPTION
Closes #39.

This PR adds a comprehensive set of table-driven unit tests for the `parseStructs` function in the `parser` package. The new tests cover a variety of struct parsing scenarios, including handling of struct tags, imports, and nested structs, ensuring that the parsing logic is robust and correct.

**Testing improvements:**

* Added `parser_test.go` with multiple test cases for `parseStructs`, covering cases such as no structs, single and multiple structs (with and without validation tags), structs with imports, and nested structs.
* Introduced a helper function `structsContentHelper` to aid in comparing and displaying differences between expected and actual parsed struct outputs, improving test clarity and debugging.