### PR TITLE
support map type

### DIFF
--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -32,9 +32,11 @@ var operations = map[string]Operation{
 		CountValues:      ZERO_VALUE,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":   true,
-			"uint8":    true,
-			"[]string": true,
+			"string":      true,
+			"uint8":       true,
+			"[]string":    true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"gte": {
@@ -58,8 +60,10 @@ var operations = map[string]Operation{
 		CountValues:      ONE_VALUE,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":   true,
-			"[]string": true,
+			"string":      true,
+			"[]string":    true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"max": {
@@ -67,8 +71,10 @@ var operations = map[string]Operation{
 		CountValues:      ONE_VALUE,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":   true,
-			"[]string": true,
+			"string":      true,
+			"[]string":    true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"eq_ignore_case": {
@@ -84,8 +90,10 @@ var operations = map[string]Operation{
 		CountValues:      ONE_VALUE,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":   true,
-			"[]string": true,
+			"string":      true,
+			"[]string":    true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"neq": {
@@ -110,9 +118,11 @@ var operations = map[string]Operation{
 		CountValues:      MANY_VALUES,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":    true,
-			"[]string":  true,
-			"[N]string": true,
+			"string":      true,
+			"[]string":    true,
+			"[N]string":   true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"nin": {
@@ -120,9 +130,11 @@ var operations = map[string]Operation{
 		CountValues:      MANY_VALUES,
 		IsFieldOperation: false,
 		ValidTypes: map[string]bool{
-			"string":    true,
-			"[]string":  true,
-			"[N]string": true,
+			"string":      true,
+			"[]string":    true,
+			"[N]string":   true,
+			"map[string]": true,
+			"map[uint8]":  true,
 		},
 	},
 	"email": {

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -1,0 +1,212 @@
+package analyzer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opencodeco/validgen/internal/parser"
+)
+
+func TestValidFieldOperationsByType(t *testing.T) {
+	tests := []struct {
+		fieldType string
+		op        string
+	}{
+		// eq operations
+		{
+			fieldType: "string",
+			op:        "eq=abc",
+		},
+		{
+			fieldType: "uint8",
+			op:        "eq=123",
+		},
+		{
+			fieldType: "bool",
+			op:        "eq=true",
+		},
+
+		// required operations
+		{
+			fieldType: "string",
+			op:        "required",
+		},
+		{
+			fieldType: "uint8",
+			op:        "required",
+		},
+		{
+			fieldType: "[]string",
+			op:        "required",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "required",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "required",
+		},
+
+		// gte operations
+		{
+			fieldType: "uint8",
+			op:        "gte=123",
+		},
+
+		// lte operations
+		{
+			fieldType: "uint8",
+			op:        "lte=123",
+		},
+
+		// min operations
+		{
+			fieldType: "string",
+			op:        "min=3",
+		},
+		{
+			fieldType: "[]string",
+			op:        "min=3",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "min=3",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "min=3",
+		},
+
+		// max operations
+		{
+			fieldType: "string",
+			op:        "max=3",
+		},
+		{
+			fieldType: "[]string",
+			op:        "max=3",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "max=3",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "max=3",
+		},
+
+		// eq_ignore_case operations
+		{
+			fieldType: "string",
+			op:        "eq_ignore_case=abc",
+		},
+
+		// len operations
+		{
+			fieldType: "string",
+			op:        "len=3",
+		},
+		{
+			fieldType: "[]string",
+			op:        "len=3",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "len=3",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "len=3",
+		},
+
+		// neq operations
+		{
+			fieldType: "string",
+			op:        "neq=abc",
+		},
+		{
+			fieldType: "bool",
+			op:        "neq=true",
+		},
+
+		// neq_ignore_case operations
+		{
+			fieldType: "string",
+			op:        "neq_ignore_case=abc",
+		},
+
+		// in operations
+		{
+			fieldType: "string",
+			op:        "in=abc",
+		},
+		{
+			fieldType: "[]string",
+			op:        "in=abc",
+		},
+		{
+			fieldType: "[5]string",
+			op:        "in=abc",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "in=abc",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "in=123",
+		},
+
+		// nin operations
+		{
+			fieldType: "string",
+			op:        "nin=abc",
+		},
+		{
+			fieldType: "[]string",
+			op:        "nin=abc",
+		},
+		{
+			fieldType: "[5]string",
+			op:        "nin=abc",
+		},
+		{
+			fieldType: "map[string]",
+			op:        "nin=abc",
+		},
+		{
+			fieldType: "map[uint8]",
+			op:        "nin=123",
+		},
+
+		// email operations
+		{
+			fieldType: "string",
+			op:        "email",
+		},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("valid %s %s", tt.fieldType, tt.op)
+		t.Run(testName, func(t *testing.T) {
+			arg := []*parser.Struct{
+				{
+					Fields: []parser.Field{
+						{
+							FieldName: "Field",
+							Type:      tt.fieldType,
+							Tag:       fmt.Sprintf(`valid:"%s"`, tt.op),
+						},
+					},
+				},
+			}
+
+			_, err := AnalyzeStructs(arg)
+			if err != nil {
+				t.Errorf("AnalyzeStructs() error = %v, wantErr %v", err, nil)
+				return
+			}
+		})
+	}
+}

--- a/internal/codegenerator/build_validator_test.go
+++ b/internal/codegenerator/build_validator_test.go
@@ -201,6 +201,32 @@ errs = append(errs, types.NewValidationError("boolField must be equal to true"))
 }
 `,
 		},
+
+		// Map type
+		{
+			name: "if code with string map",
+			args: args{
+				fieldName:       "mapField",
+				fieldType:       "map[string]",
+				fieldValidation: "len=3",
+			},
+			want: `if !(len(obj.mapField) == 3) {
+errs = append(errs, types.NewValidationError("mapField must have exactly 3 elements"))
+}
+`,
+		},
+		{
+			name: "if code with uint8 map",
+			args: args{
+				fieldName:       "mapField",
+				fieldType:       "map[uint8]",
+				fieldValidation: "len=3",
+			},
+			want: `if !(len(obj.mapField) == 3) {
+errs = append(errs, types.NewValidationError("mapField must have exactly 3 elements"))
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/codegenerator/condition_table.go
+++ b/internal/codegenerator/condition_table.go
@@ -54,6 +54,16 @@ var operationTable = map[string]Operation{
 				concatOperator: "",
 				errorMessage:   "{{.Name}} must not be empty",
 			},
+			"map[string]": {
+				operation:      `len(obj.{{.Name}}) >= 1`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must not be empty",
+			},
+			"map[uint8]": {
+				operation:      `len(obj.{{.Name}}) >= 1`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must not be empty",
+			},
 		},
 	},
 	"gte": {
@@ -89,6 +99,16 @@ var operationTable = map[string]Operation{
 				concatOperator: "",
 				errorMessage:   "{{.Name}} must have at least {{.Target}} elements",
 			},
+			"map[string]": {
+				operation:      `len(obj.{{.Name}}) >= {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have at least {{.Target}} elements",
+			},
+			"map[uint8]": {
+				operation:      `len(obj.{{.Name}}) >= {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have at least {{.Target}} elements",
+			},
 		},
 	},
 	"max": {
@@ -100,6 +120,16 @@ var operationTable = map[string]Operation{
 				errorMessage:   "{{.Name}} length must be <= {{.Target}}",
 			},
 			"[]string": {
+				operation:      `len(obj.{{.Name}}) <= {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have at most {{.Target}} elements",
+			},
+			"map[string]": {
+				operation:      `len(obj.{{.Name}}) <= {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have at most {{.Target}} elements",
+			},
+			"map[uint8]": {
 				operation:      `len(obj.{{.Name}}) <= {{.Target}}`,
 				concatOperator: "",
 				errorMessage:   "{{.Name}} must have at most {{.Target}} elements",
@@ -125,6 +155,16 @@ var operationTable = map[string]Operation{
 				errorMessage:   "{{.Name}} length must be {{.Target}}",
 			},
 			"[]string": {
+				operation:      `len(obj.{{.Name}}) == {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have exactly {{.Target}} elements",
+			},
+			"map[string]": {
+				operation:      `len(obj.{{.Name}}) == {{.Target}}`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} must have exactly {{.Target}} elements",
+			},
+			"map[uint8]": {
 				operation:      `len(obj.{{.Name}}) == {{.Target}}`,
 				concatOperator: "",
 				errorMessage:   "{{.Name}} must have exactly {{.Target}} elements",
@@ -174,6 +214,16 @@ var operationTable = map[string]Operation{
 				concatOperator: "",
 				errorMessage:   "{{.Name}} elements must be one of {{.Targets}}",
 			},
+			"map[string]": {
+				operation:      `types.MapOnlyContains(obj.{{.Name}}, {{.TargetsAsStringSlice}})`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} elements must be one of {{.Targets}}",
+			},
+			"map[uint8]": {
+				operation:      `types.MapOnlyContains(obj.{{.Name}}, {{.TargetsAsNumericSlice}})`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} elements must be one of {{.Targets}}",
+			},
 		},
 	},
 	"nin": {
@@ -191,6 +241,16 @@ var operationTable = map[string]Operation{
 			},
 			"[N]string": {
 				operation:      `types.SliceNotContains(obj.{{.Name}}[:], {{.TargetsAsStringSlice}})`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} elements must not be one of {{.Targets}}",
+			},
+			"map[string]": {
+				operation:      `types.MapNotContains(obj.{{.Name}}, {{.TargetsAsStringSlice}})`,
+				concatOperator: "",
+				errorMessage:   "{{.Name}} elements must not be one of {{.Targets}}",
+			},
+			"map[uint8]": {
+				operation:      `types.MapNotContains(obj.{{.Name}}, {{.TargetsAsNumericSlice}})`,
 				concatOperator: "",
 				errorMessage:   "{{.Name}} elements must not be one of {{.Targets}}",
 			},

--- a/internal/codegenerator/get_test_elements_map_test.go
+++ b/internal/codegenerator/get_test_elements_map_test.go
@@ -1,0 +1,182 @@
+package codegenerator
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefineTestElementsWithMapFields(t *testing.T) {
+	type args struct {
+		fieldName       string
+		fieldType       string
+		fieldValidation string
+	}
+	tests := []struct {
+		name string
+		args args
+		want TestElements
+	}{
+		// string map operations
+		{
+			name: "required string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "required",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) >= 1`},
+				errorMessage: "myfield must not be empty",
+			},
+		},
+		{
+			name: "len string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "len=3",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) == 3`},
+				errorMessage: "myfield must have exactly 3 elements",
+			},
+		},
+		{
+			name: "min string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "min=2",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) >= 2`},
+				errorMessage: "myfield must have at least 2 elements",
+			},
+		},
+		{
+			name: "max string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "max=5",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) <= 5`},
+				errorMessage: "myfield must have at most 5 elements",
+			},
+		},
+		{
+			name: "in string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "in=1 2 3",
+			},
+			want: TestElements{
+				conditions:   []string{`types.MapOnlyContains(obj.myfield, []string{"1", "2", "3"})`},
+				errorMessage: "myfield elements must be one of '1' '2' '3'",
+			},
+		},
+		{
+			name: "nin string map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[string]",
+				fieldValidation: "nin=1 2 3",
+			},
+			want: TestElements{
+				conditions:   []string{`types.MapNotContains(obj.myfield, []string{"1", "2", "3"})`},
+				errorMessage: "myfield elements must not be one of '1' '2' '3'",
+			},
+		},
+
+		// uint8 map operations
+		{
+			name: "required uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "required",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) >= 1`},
+				errorMessage: "myfield must not be empty",
+			},
+		},
+		{
+			name: "len uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "len=3",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) == 3`},
+				errorMessage: "myfield must have exactly 3 elements",
+			},
+		},
+		{
+			name: "min uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "min=2",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) >= 2`},
+				errorMessage: "myfield must have at least 2 elements",
+			},
+		},
+		{
+			name: "max uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "max=5",
+			},
+			want: TestElements{
+				conditions:   []string{`len(obj.myfield) <= 5`},
+				errorMessage: "myfield must have at most 5 elements",
+			},
+		},
+		{
+			name: "in uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "in=1 2 3",
+			},
+			want: TestElements{
+				conditions:   []string{`types.MapOnlyContains(obj.myfield, []uint8{1, 2, 3})`},
+				errorMessage: "myfield elements must be one of '1' '2' '3'",
+			},
+		},
+		{
+			name: "nin uint8 map",
+			args: args{
+				fieldName:       "myfield",
+				fieldType:       "map[uint8]",
+				fieldValidation: "nin=1 2 3",
+			},
+			want: TestElements{
+				conditions:   []string{`types.MapNotContains(obj.myfield, []uint8{1, 2, 3})`},
+				errorMessage: "myfield elements must not be one of '1' '2' '3'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantErr := false
+			validation := AssertParserValidation(t, tt.args.fieldValidation)
+			got, err := DefineTestElements(tt.args.fieldName, tt.args.fieldType, validation)
+			if (err != nil) != wantErr {
+				t.Errorf("DefineTestElements() error = %v, wantErr %v", err, wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefineTestElements() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/codegenerator/test_elements.go
+++ b/internal/codegenerator/test_elements.go
@@ -36,8 +36,12 @@ func DefineTestElements(fieldName, fieldType string, fieldValidation *analyzer.V
 		targetValue = condition.operation
 		targetValues = "'" + condition.operation + "' "
 	case analyzer.ONE_VALUE, analyzer.MANY_VALUES:
+		// TODO: refactor: When parsing, divide the type into Literal Type (array, map, etc.), Elemental Type (base type), and size (for arrays).
+		// Code below split basic type from slices and maps
 		basicType := strings.TrimPrefix(fieldType, "[N]")
 		basicType = strings.TrimPrefix(basicType, "[]")
+		basicType = strings.TrimPrefix(basicType, "map[")
+		basicType = strings.TrimSuffix(basicType, "]")
 		valuesAsNumericSlice, valuesAsStringSlice := normalizeSlicesAsCode(basicType, values)
 
 		for _, value := range values {
@@ -90,7 +94,7 @@ func replaceTargetInErrors(text, target, targets string) string {
 func normalizeSlicesAsCode(basicType string, values []string) (string, string) {
 
 	valuesAsNumericSlice := "[]" + basicType + "{"
-	valuesAsStringSlice := "[]" + basicType + "{"
+	valuesAsStringSlice := "[]" + "string" + "{"
 
 	for i, value := range values {
 		if i != 0 {

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -3,6 +3,11 @@ package common
 import "strings"
 
 func IsGoType(fieldType string) bool {
+	if strings.HasPrefix(fieldType, "map[") {
+		// REFACTOR!
+		return true
+	}
+
 	fieldType = strings.TrimPrefix(fieldType, "[]")
 	fieldType = strings.TrimPrefix(fieldType, "[N]")
 
@@ -23,6 +28,7 @@ func IsGoType(fieldType string) bool {
 		// "float64":    {},
 		// "complex64":  {},
 		// "complex128": {},
+		"map": {},
 	}
 
 	_, ok := goTypes[fieldType]

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -172,6 +172,11 @@ func appendFields(structType *ast.StructType, packageName string, cstruct *Struc
 			nestedPkgName := v.X.(*ast.Ident).Name
 			fieldType, fieldTag = extractNestedFieldTypeAndTag(nestedPkgName, v.Sel.Name, fieldTag)
 			appendFieldNames = true
+
+		case *ast.MapType:
+			fieldType = fmt.Sprintf("map[%s]", v.Key.(*ast.Ident).Name)
+			_, fieldTag = extractFieldTypeAndTag(packageName, fieldType, fieldTag)
+			appendFieldNames = true
 		}
 
 		if appendFieldNames {
@@ -192,6 +197,7 @@ func extractFieldTypeAndTag(packageName, fieldType, fieldTag string) (string, st
 	if !common.IsGoType(fieldType) {
 		rFieldType = common.KeyPath(packageName, fieldType)
 	}
+
 	rFieldTag := ""
 	if fieldTag != "" {
 		rFieldTag = fieldTag

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -352,6 +352,47 @@ func TestParseStructsOk(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "Map type",
+			args: args{
+				fullpath: "example/main.go",
+				src: "package main\n" +
+					"type AllTypes struct {\n" +
+					"	MapField1    map[string]string `valid:\"required\"`\n" +
+					"	MapField2    map[string]uint8 `valid:\"len=3\"`\n" +
+					"	MapField3    map[uint8]string `valid:\"max=5\"`\n" +
+					"}\n" +
+
+					"func main() {\n" +
+					"}\n",
+			},
+			want: []*Struct{
+				{
+					StructName:  "AllTypes",
+					Path:        "./example",
+					PackageName: "main",
+					Fields: []Field{
+						{
+							FieldName: "MapField1",
+							Type:      "map[string]",
+							Tag:       "valid:\"required\"",
+						},
+						{
+							FieldName: "MapField2",
+							Type:      "map[string]",
+							Tag:       "valid:\"len=3\"",
+						},
+						{
+							FieldName: "MapField3",
+							Type:      "map[uint8]",
+							Tag:       "valid:\"max=5\"",
+						},
+					},
+					Imports: map[string]Import{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/endtoend/main.go
+++ b/tests/endtoend/main.go
@@ -41,6 +41,8 @@ func main() {
 	cmp_between_inner_fields_tests()
 	cmp_between_nested_fields_tests()
 	bool_tests()
+	map_string_tests()
+	map_uint8_tests()
 
 	log.Println("finishing tests")
 }

--- a/tests/endtoend/map_numeric.go
+++ b/tests/endtoend/map_numeric.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+)
+
+type MapUint8 struct {
+	FieldRequired map[uint8]string `valid:"required"`
+	FieldMin      map[uint8]string `valid:"min=2"`
+	FieldMax      map[uint8]string `valid:"max=5"`
+	FieldLen      map[uint8]string `valid:"len=3"`
+	FieldIn       map[uint8]string `valid:"in=1 2 3"`
+	FieldNotIn    map[uint8]string `valid:"nin=1 2 3"`
+}
+
+func map_uint8_tests() {
+	log.Println("starting map uint8 tests")
+
+	var expectedMsgErrors []string
+	var errs []error
+
+	// Test case 1: All failure scenarios
+	v := &MapUint8{
+		FieldRequired: map[uint8]string{},
+		FieldMin:      map[uint8]string{1: "1"},
+		FieldMax:      map[uint8]string{1: "1", 2: "2", 3: "3", 4: "4", 5: "5", 6: "6"},
+		FieldLen:      map[uint8]string{1: "1", 2: "2"},
+		FieldIn:       map[uint8]string{4: "d"},
+		FieldNotIn:    map[uint8]string{1: "a", 2: "b"},
+	}
+	expectedMsgErrors = []string{
+		"FieldRequired must not be empty",
+		"FieldMin must have at least 2 elements",
+		"FieldMax must have at most 5 elements",
+		"FieldLen must have exactly 3 elements",
+		"FieldIn elements must be one of '1' '2' '3'",
+		"FieldNotIn elements must not be one of '1' '2' '3'",
+	}
+	errs = MapUint8Validate(v)
+	if !expectedMsgErrorsOk(errs, expectedMsgErrors) {
+		log.Fatalf("error = %v, wantErr %v", errs, expectedMsgErrors)
+	}
+
+	// Test case 2: All valid input
+	v = &MapUint8{
+		FieldRequired: map[uint8]string{1: "1", 2: "2"},
+		FieldMin:      map[uint8]string{1: "1", 2: "2"},
+		FieldMax:      map[uint8]string{1: "1", 2: "2", 3: "3", 4: "4"},
+		FieldLen:      map[uint8]string{1: "1", 2: "2", 3: "3"},
+		FieldIn:       map[uint8]string{1: "1", 2: "2", 3: "3"},
+		FieldNotIn:    map[uint8]string{4: "d", 5: "e", 6: "f"},
+	}
+	expectedMsgErrors = nil
+	errs = MapUint8Validate(v)
+	if !expectedMsgErrorsOk(errs, expectedMsgErrors) {
+		log.Fatalf("error = %v, wantErr %v", errs, expectedMsgErrors)
+	}
+
+	log.Println("map uint8 tests ok")
+}

--- a/tests/endtoend/map_string.go
+++ b/tests/endtoend/map_string.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+)
+
+type MapString struct {
+	FieldRequired map[string]string `valid:"required"`
+	FieldMin      map[string]string `valid:"min=2"`
+	FieldMax      map[string]string `valid:"max=5"`
+	FieldLen      map[string]string `valid:"len=3"`
+	FieldIn       map[string]string `valid:"in=a b c"`
+	FieldNotIn    map[string]string `valid:"nin=a b c"`
+}
+
+func map_string_tests() {
+	log.Println("starting map string tests")
+
+	var expectedMsgErrors []string
+	var errs []error
+
+	// Test case 1: All failure scenarios
+	v := &MapString{
+		FieldRequired: map[string]string{},
+		FieldMin:      map[string]string{"1": "1"},
+		FieldMax:      map[string]string{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6"},
+		FieldLen:      map[string]string{"1": "1", "2": "2"},
+		FieldIn:       map[string]string{"d": "d"},
+		FieldNotIn:    map[string]string{"a": "a", "b": "b"},
+	}
+	expectedMsgErrors = []string{
+		"FieldRequired must not be empty",
+		"FieldMin must have at least 2 elements",
+		"FieldMax must have at most 5 elements",
+		"FieldLen must have exactly 3 elements",
+		"FieldIn elements must be one of 'a' 'b' 'c'",
+		"FieldNotIn elements must not be one of 'a' 'b' 'c'",
+	}
+	errs = MapStringValidate(v)
+	if !expectedMsgErrorsOk(errs, expectedMsgErrors) {
+		log.Fatalf("error = %v, wantErr %v", errs, expectedMsgErrors)
+	}
+
+	// Test case 2: All valid input
+	v = &MapString{
+		FieldRequired: map[string]string{"1": "1", "2": "2"},
+		FieldMin:      map[string]string{"1": "1", "2": "2"},
+		FieldMax:      map[string]string{"1": "1", "2": "2", "3": "3", "4": "4"},
+		FieldLen:      map[string]string{"1": "1", "2": "2", "3": "3"},
+		FieldIn:       map[string]string{"a": "a", "b": "b", "c": "c"},
+		FieldNotIn:    map[string]string{"d": "d", "e": "e", "f": "f"},
+	}
+	expectedMsgErrors = nil
+	errs = MapStringValidate(v)
+	if !expectedMsgErrorsOk(errs, expectedMsgErrors) {
+		log.Fatalf("error = %v, wantErr %v", errs, expectedMsgErrors)
+	}
+
+	log.Println("map string tests ok")
+}

--- a/tests/endtoend/validator__.go
+++ b/tests/endtoend/validator__.go
@@ -146,6 +146,50 @@ func CmpNestedUint8FieldsValidate(obj *CmpNestedUint8Fields) []error {
 	}
 	return errs
 }
+func MapStringValidate(obj *MapString) []error {
+	var errs []error
+	if !(len(obj.FieldRequired) >= 1) {
+		errs = append(errs, types.NewValidationError("FieldRequired must not be empty"))
+	}
+	if !(len(obj.FieldMin) >= 2) {
+		errs = append(errs, types.NewValidationError("FieldMin must have at least 2 elements"))
+	}
+	if !(len(obj.FieldMax) <= 5) {
+		errs = append(errs, types.NewValidationError("FieldMax must have at most 5 elements"))
+	}
+	if !(len(obj.FieldLen) == 3) {
+		errs = append(errs, types.NewValidationError("FieldLen must have exactly 3 elements"))
+	}
+	if !(types.MapOnlyContains(obj.FieldIn, []string{"a", "b", "c"})) {
+		errs = append(errs, types.NewValidationError("FieldIn elements must be one of 'a' 'b' 'c'"))
+	}
+	if !(types.MapNotContains(obj.FieldNotIn, []string{"a", "b", "c"})) {
+		errs = append(errs, types.NewValidationError("FieldNotIn elements must not be one of 'a' 'b' 'c'"))
+	}
+	return errs
+}
+func MapUint8Validate(obj *MapUint8) []error {
+	var errs []error
+	if !(len(obj.FieldRequired) >= 1) {
+		errs = append(errs, types.NewValidationError("FieldRequired must not be empty"))
+	}
+	if !(len(obj.FieldMin) >= 2) {
+		errs = append(errs, types.NewValidationError("FieldMin must have at least 2 elements"))
+	}
+	if !(len(obj.FieldMax) <= 5) {
+		errs = append(errs, types.NewValidationError("FieldMax must have at most 5 elements"))
+	}
+	if !(len(obj.FieldLen) == 3) {
+		errs = append(errs, types.NewValidationError("FieldLen must have exactly 3 elements"))
+	}
+	if !(types.MapOnlyContains(obj.FieldIn, []uint8{1, 2, 3})) {
+		errs = append(errs, types.NewValidationError("FieldIn elements must be one of '1' '2' '3'"))
+	}
+	if !(types.MapNotContains(obj.FieldNotIn, []uint8{1, 2, 3})) {
+		errs = append(errs, types.NewValidationError("FieldNotIn elements must not be one of '1' '2' '3'"))
+	}
+	return errs
+}
 func SliceStringValidate(obj *SliceString) []error {
 	var errs []error
 	if !(len(obj.TypesRequired) != 0) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -15,5 +15,5 @@ func NewValidationError(format string, a ...any) error {
 }
 
 func (e ValidationError) Error() string {
-	return fmt.Sprintf("%s", e.Msg)
+	return e.Msg
 }

--- a/types/map_utils.go
+++ b/types/map_utils.go
@@ -1,0 +1,23 @@
+package types
+
+import "slices"
+
+func MapOnlyContains[K comparable, V any](m map[K]V, e []K) bool {
+	for k := range m {
+		if !slices.Contains(e, k) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func MapNotContains[K comparable, V any](m map[K]V, e []K) bool {
+	for k := range m {
+		if slices.Contains(e, k) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Closes #58 

This PR adds support for validating Go map types (`map[string]` and `map[uint8]`) in the codebase. It updates the parser, analyzer, and code generator to correctly recognize, process, and generate validation logic for these map types. Comprehensive tests have been added to ensure correct behavior for all supported validation operations on maps.

**Support for map types in validation:**

* Parser now recognizes map fields and correctly parses their types and tags, enabling validation for struct fields of type `map[string]` and `map[uint8]`. (`internal/parser/parser.go`, `internal/parser/parser_test.go`) [[1]](diffhunk://#diff-d1655fd776ca5fcf2821d7a478d18e80e68fc75d43a8aabeb5fbb07197c4f3ccR175-R179) [[2]](diffhunk://#diff-d1655fd776ca5fcf2821d7a478d18e80e68fc75d43a8aabeb5fbb07197c4f3ccR200) [[3]](diffhunk://#diff-f8625058bbc944e30e69a0e09139ecd3e0d510f768ecebf132c5182d27f67503R355-R395)
* Analyzer and code generator extended to support validation operations (`required`, `len`, `min`, `max`, `in`, `nin`) for map types, updating the valid types and condition tables accordingly. (`internal/analyzer/operations.go`, `internal/codegenerator/condition_table.go`) [[1]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R38-R39) [[2]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R65-R66) [[3]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R76-R77) [[4]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R95-R96) [[5]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R124-R125) [[6]](diffhunk://#diff-9263870925ee44d5ae86bdafacdb4f32b03771bcefeb6b66081a8129d5c9fe17R136-R137) [[7]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR57-R66) [[8]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR102-R111) [[9]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR127-R136) [[10]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR162-R171) [[11]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR217-R226) [[12]](diffhunk://#diff-f07ab3269d99e08d1fb035fe37dede7ca48c2c057244b352c10f8d9a44664e3bR247-R256)

**Testing and validation logic:**

* Added unit tests for analyzer and code generator to cover all supported operations on map fields, ensuring correct validation logic and error messages. (`internal/analyzer/operations_test.go`, `internal/codegenerator/get_test_elements_map_test.go`, `internal/codegenerator/build_validator_test.go`) [[1]](diffhunk://#diff-a1b72c812654b6ef62b3883a95eca16dd225ab76c57a29c4570cfe53c1d61589R1-R212) [[2]](diffhunk://#diff-493d4264a4c0c48699f271f33d9123e59857a2ea85b2126b388182b3e077b9aaR1-R182) [[3]](diffhunk://#diff-8d32a9c408197046acde77ba1dfab1521cc0bc32365f0f98fa4c956dbadd3d39R202-R227)
* End-to-end tests updated to include cases for map validation. (`tests/endtoend/main.go`)

**Utility and normalization improvements:**

* Utility functions now correctly identify map types as valid Go types and normalize their element types for code generation. (`internal/common/utils.go`, `internal/codegenerator/test_elements.go`) [[1]](diffhunk://#diff-ae127f9da6e44ed5a38a41c263f72c6e4d1b6da0a62a774df5861064d70e99a1R6-R10) [[2]](diffhunk://#diff-ae127f9da6e44ed5a38a41c263f72c6e4d1b6da0a62a774df5861064d70e99a1R31) [[3]](diffhunk://#diff-a805abe62add9666cbcd835268eed6be4343bcd6647ec608325825137aadc6a6R39-R44) [[4]](diffhunk://#diff-a805abe62add9666cbcd835268eed6be4343bcd6647ec608325825137aadc6a6L93-R97)